### PR TITLE
Add haskell-minithesis to port links list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ There are a number of ports of minithesis (:tada:). The following are the ones I
 
 * Martin Janiczek's Elm port, [elm-minithesis](https://github.com/Janiczek/elm-minithesis)
 * Jack Firth's racket port, [miniracksis](https://github.com/jackfirth/miniracksis/)
+* Amanda Walker's Haskell port, [haskell-minithesis](https://github.com/AnOctopus/haskell-minithesis)
 
 If you write a port, please submit a pull request to add it to the list!


### PR DESCRIPTION
I haven't looked to see how complete the other ports in the readme are, but I have an implementation and it might be of interest to some people, even though it's as much a project for me to learn Haskell as for learning about hypothesis. I actually started it before you created minithesis, but the implementation got much easier once I had a simple implementation to work from. 

Fun fact, it was from learning that you started hypothesis as a means to learn Python that pushed me into finally working on my own implementation to learn Haskell. 