### PR TITLE
Add Julia Port

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ There are a number of ports of minithesis (:tada:). The following are the ones I
 * Amanda Walker's Haskell port, [haskell-minithesis](https://github.com/AnOctopus/haskell-minithesis)
 * Dmitry Dygalo and Rik de Kort's Rust port, [minithesis-rust](https://github.com/Rik-de-Kort/minithesis-rust)
 * Justin Blank's Java port, [jiminy-thesis](https://github.com/hyperpape/jiminy-thesis)
+* Valentin Bogad's Julia port, [MiniThesis.jl](https://github.com/Seelengrab/MiniThesis.jl)
 
 If you write a port, please submit a pull request to add it to the list!


### PR DESCRIPTION
This was a delight to implement - I mostly followed the Rust port since I'm more familiar with Rust. If there's something missing, it's probably because the Rust port also doesn't have it :)

I like how the `TestCase` handling is very explicit about storing the chosen path; counter to Hedgehog, where things are mostly implicit in the call graph. Certainly gave me a new perspective, thank you for the project!